### PR TITLE
Replace isFunction

### DIFF
--- a/event.js
+++ b/event.js
@@ -663,7 +663,7 @@ jsaction.event.recreateTouchEventAsClick = function(event) {
   click['type'] = jsaction.EventType.CLICK;
   for (const p in event) {
     const v = event[p];
-    if (p != 'type' && p != 'srcElement' && !goog.isFunction(v)) {
+    if (p != 'type' && p != 'srcElement' && !(typeof v === 'function')) {
       click[p] = v;
     }
   }


### PR DESCRIPTION
`goog.isFunction` was recently deprecated and removed, so this changeset replaces it with `typeof v === 'function'`.